### PR TITLE
Add build/start scripts for production + documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,20 @@ username: admin
 password: admin
 ```
 
+## Production Deploy
+
+- Run `./build-prod.sh` on machine with access to our Quay registry
+- Run `./provsn jenkins run './start-prod.sh $VERSION'` from ipfs/infrastructure
+	replace $VERSION with which commit you want to deploy
+
+### Setting up new host
+
+New hosts need:
+
+- Docker installed
+- Docker Login generated for Quay read-only access
+- User `jenkins` on host for file permissions in running container
+- Initial clone of ipfs/jenkins to home directory of jenkins user
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ password: admin
 ## Production Deploy
 
 - Run `./build-prod.sh` on machine with access to our Quay registry
-- Run `./provsn jenkins run './start-prod.sh $VERSION'` from ipfs/infrastructure
+- Run `./provsn exec jenkins '/path/to/start-prod.sh $VERSION'` from ipfs/infrastructure
 	replace $VERSION with which commit you want to deploy
 
 ### Setting up new host

--- a/build-prod.sh
+++ b/build-prod.sh
@@ -1,0 +1,21 @@
+#! /usr/bin/env bash
+
+set -e
+
+IMAGE_NAME="quay.io/ipfs/jenkins"
+
+if [[ -n $(git status --porcelain) ]]; then
+	echo "Repository is dirty, please reset or commit your changes"
+	exit 1
+fi
+
+COMMIT=$(git rev-parse HEAD)
+CURRENT_IMAGE="$IMAGE_NAME:$COMMIT"
+
+echo "## Building $CURRENT_IMAGE"
+
+docker build -t $CURRENT_IMAGE .
+docker tag $CURRENT_IMAGE $IMAGE_NAME:latest
+docker push $IMAGE_NAME
+
+echo "## Built and pushed $CURRENT_IMAGE"

--- a/start-prod.sh
+++ b/start-prod.sh
@@ -22,6 +22,8 @@ else
 	git fetch
 	git checkout $VERSION
 	# TODO changes to config would happen here, decrypting secrets and such
+	# for now, just clean out all the users
+	rm -r config/users/*
 fi
 
 # Image deploy

--- a/start-prod.sh
+++ b/start-prod.sh
@@ -1,0 +1,37 @@
+#! /usr/bin/env bash
+
+set -e
+
+if [ -z "$1" ]
+then
+	echo "Version/Commit is required as first argument"
+	exit 1
+fi
+# Which version/commit we're gonna use
+VERSION="$1"
+
+# Which docker image we're gonna use
+IMAGE="quay.io/ipfs/jenkins"
+
+# Git checkout
+CURRENT_COMMIT=$(git rev-parse HEAD)
+if [ "$VERSION" == "$CURRENT_COMMIT" ]; then
+	echo "SCM up-to-date"
+else
+	echo "Updating config"
+	git fetch
+	git checkout $VERSION
+	# TODO changes to config would happen here, decrypting secrets and such
+fi
+
+# Image deploy
+IMAGE_TO_DEPLOY="$IMAGE:$VERSION"
+CURRENT_IMAGE=$(docker inspect jenkins -f "{{ .Config.Image }}" || echo)
+if [ "$IMAGE_TO_DEPLOY" == "$CURRENT_IMAGE" ]; then
+	echo "Image up-to-date"
+else
+	echo "Different image currently running, deploying new image"
+	docker stop jenkins || true
+	docker rm jenkins || true
+	docker run -d --name jenkins -p 80:8080 -v $(pwd)/config $IMAGE_TO_DEPLOY
+fi

--- a/start-prod.sh
+++ b/start-prod.sh
@@ -35,5 +35,10 @@ else
 	echo "Different image currently running, deploying new image"
 	docker stop jenkins || true
 	docker rm jenkins || true
-	docker run -d --name jenkins -p 80:8080 -v $(pwd)/config $IMAGE_TO_DEPLOY
+	docker run -d \
+		--name jenkins \
+		-p 80:8080 \
+		-v $(pwd)/config:/var/jenkins_home \
+		--env JAVA_OPTS=-Djenkins.install.runSetupWizard=false \
+		$IMAGE_TO_DEPLOY
 fi

--- a/start-prod.sh
+++ b/start-prod.sh
@@ -23,7 +23,7 @@ else
 	git checkout $VERSION
 	# TODO changes to config would happen here, decrypting secrets and such
 	# for now, just clean out all the users
-	rm -r config/users/*
+	rm -r config/users/* || true
 fi
 
 # Image deploy


### PR DESCRIPTION
adds build-prod.sh which builds images and pushes them to quay and start-prod.sh that fetches latest changes and possibly stops/starts container if image changed.