### PR TITLE
Basic pipeline for js-ipfs

### DIFF
--- a/config/jobs/js-ipfs/config.xml
+++ b/config/jobs/js-ipfs/config.xml
@@ -1,12 +1,34 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <flow-definition plugin="workflow-job@2.9">
+  <actions/>
   <description></description>
   <keepDependencies>false</keepDependencies>
   <properties>
+    <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@1.25.1">
+      <projectUrl>github.com/ipfs/js-ipfs/</projectUrl>
+      <displayName></displayName>
+    </com.coravy.hudson.plugins.github.GithubProjectProperty>
     <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@1.25">
       <autoRebuild>false</autoRebuild>
       <rebuildDisabled>false</rebuildDisabled>
     </com.sonyericsson.rebuild.RebuildSettings>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <net.uaznia.lukanus.hudson.plugins.gitparameter.GitParameterDefinition plugin="git-parameter@0.7.2">
+          <name>BranchOrTag</name>
+          <description>Branch Or Tag</description>
+          <uuid>66c27ace-bdba-4ec6-a97c-785beeb248fa</uuid>
+          <type>PT_BRANCH_TAG</type>
+          <branch></branch>
+          <tagFilter>*</tagFilter>
+          <branchFilter>.*</branchFilter>
+          <sortMode>NONE</sortMode>
+          <defaultValue></defaultValue>
+          <selectedValue>NONE</selectedValue>
+          <quickFilterEnabled>false</quickFilterEnabled>
+        </net.uaznia.lukanus.hudson.plugins.gitparameter.GitParameterDefinition>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
     <hudson.plugins.throttleconcurrents.ThrottleJobProperty plugin="throttle-concurrents@1.9.0">
       <maxConcurrentPerNode>0</maxConcurrentPerNode>
       <maxConcurrentTotal>0</maxConcurrentTotal>
@@ -20,11 +42,24 @@
       <triggers/>
     </org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
   </properties>
-  <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@2.24">
-    <script>node {
-   echo &apos;Hello World&apos;
-}</script>
-    <sandbox>true</sandbox>
+  <definition class="org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition" plugin="workflow-cps@2.24">
+    <scm class="hudson.plugins.git.GitSCM" plugin="git@3.0.1">
+      <configVersion>2</configVersion>
+      <userRemoteConfigs>
+        <hudson.plugins.git.UserRemoteConfig>
+          <url>https://github.com/ipfs/js-ipfs</url>
+        </hudson.plugins.git.UserRemoteConfig>
+      </userRemoteConfigs>
+      <branches>
+        <hudson.plugins.git.BranchSpec>
+          <name>${BranchOrTag}</name>
+        </hudson.plugins.git.BranchSpec>
+      </branches>
+      <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
+      <submoduleCfg class="list"/>
+      <extensions/>
+    </scm>
+    <scriptPath>Jenkinsfile</scriptPath>
   </definition>
   <triggers/>
 </flow-definition>


### PR DESCRIPTION
Works with branch https://github.com/ipfs/js-ipfs/tree/jenkins-integration

This job config contains the following:
- Set Github project to `github.com/ipfs/js-ipfs`
- Define `BranchOrTag` parameter for job, which is used to decide what to fetch from SCM
- Use `Jenkinsfile` from SCM source

Looks like this in js-ipfs

**Dockerfile:**

```Dockerfile
FROM node:6.9.4

WORKDIR /usr/src/app

COPY package.json /usr/src/app/package.json

RUN npm install

COPY . /usr/src/app

CMD ["npm", "run", "test:unit:node"]
```

**Jenkinsfile:**

```Groovy
node {
	def VERSION = "latest"
	stage("Checkout") {
		git branch: 'jenkins-integration', url: 'https://github.com/ipfs/js-ipfs.git'
		VERSION = sh(returnStdout: true, script: "git rev-parse HEAD").trim()
	}
	stage("Build") {
		sh "docker build -t quay.io/ipfs/js-ipfs:$VERSION ."
	}
	stage("Test") {
		sh "docker run quay.io/ipfs/js-ipfs:$VERSION"
	}
}
```

In the future, we'll have docker base-images for all JS projects + shared-libs for the Jenkinsfile so definition would be more similar to this:

```
node {
  runCheckout(),
  runBuild(),
  runTest()
}
```

Or even implicit Jenkinsfile if some rule matches.