### PR TITLE
fix name swap in go-ipfs (go test <-> sharness)

### DIFF
--- a/config/org.jenkinsci.plugins.configfiles.GlobalConfigFiles.xml
+++ b/config/org.jenkinsci.plugins.configfiles.GlobalConfigFiles.xml
@@ -72,12 +72,12 @@ node {
 
     stage(&quot;Tests &amp; Coverage&quot;) {
       parallel(
-        &apos;sharness&apos;: { node {
+        &apos;go test&apos;: { node {
           image.withRun runArgs(), { c -&gt;
             sh &quot;$dexec ${c.id} make -j3 -Otarget test_go_expensive&quot;
           }
         }},
-        &apos;go test&apos;: { node {
+        &apos;sharness&apos;: { node {
           image.withRun runArgs(), { c1 -&gt;
             sh &quot;$dexec ${c1.id} make -j3 -Otarget test_sharness_expensive&quot;
           }


### PR DESCRIPTION
In go-ipfs Jenkins, sharness tests have the pipeline label "go test" and vice versa. This is an attempt to fix this.