### PR TITLE
Give jenkins more memory

### DIFF
--- a/start-prod.sh
+++ b/start-prod.sh
@@ -42,6 +42,6 @@ else
 		-v $(pwd)/jenkins-secrets:/home/jenkins/secrets \
 		--group-add "$(getent group docker | cut -d':' -f 3)" \
 		-v /var/run/docker.sock:/var/run/docker.sock \
-		--env JAVA_OPTS=-Djenkins.install.runSetupWizard=false \
+		--env JAVA_OPTS="-Xmx4096m -Djenkins.install.runSetupWizard=false" \
 		$IMAGE_TO_DEPLOY
 fi


### PR DESCRIPTION
By default Jenkins uses 256M, which makes it painfully slow (caused by GC) for any deployment that has more than few light jobs. Picked 4G as it seems to be a reasonable amount of memory.

(I'm not sure if this is the right place to put this)