### PR TITLE
Don't start ipfs when building ami image

### DIFF
--- a/images/linux.json
+++ b/images/linux.json
@@ -37,8 +37,7 @@
       "wget https://dist.ipfs.io/go-ipfs/v0.4.13/go-ipfs_v0.4.13_linux-amd64.tar.gz",
       "tar xfv go-ipfs_v0.4.13_linux-amd64.tar.gz",
       "cd go-ipfs && sudo ./install.sh",
-      "sudo mv /tmp/ipfs.service /etc/systemd/system/ipfs.service",
-      "sudo systemctl start ipfs"
+      "sudo mv /tmp/ipfs.service /etc/systemd/system/ipfs.service"
     ]
   }, {
     "type": "shell",


### PR DESCRIPTION
Fixes ipfs/testing#136

When starting the IPFS daemon, we run it with `--init` and since we only
generate one image and deploy to many machines, this lead to every
worker having the same Peer ID but on different IP addresses.

Down the line, in the website jobs, Jenkins master always though it
already was connected to a worker when reality, it was connected to a
worker using the same Peer ID but not the same IP.

Now instead we only run `systemctl start ipfs` when booting the
instance rather than building the image, solving the problem and each
worker now have their own Peer ID.

License: MIT
Signed-off-by: Victor Bjelkholm <git@victor.earth>